### PR TITLE
APPCOM-411: Python 3.11 support

### DIFF
--- a/aiocometd/_metadata.py
+++ b/aiocometd/_metadata.py
@@ -2,12 +2,11 @@
 TITLE = "aiocometd"
 DESCRIPTION = "CometD client for asyncio"
 KEYWORDS = "asyncio aiohttp comet cometd bayeux push streaming"
-URL = "https://github.com/robertmrk/aiocometd"
+URL = "https://github.com/hyperscience/aiocometd"
 PROJECT_URLS = {
     "CI": "https://travis-ci.org/robertmrk/aiocometd",
     "Coverage": "https://coveralls.io/github/robertmrk/aiocometd",
     "Docs": "http://aiocometd.readthedocs.io/"
 }
-VERSION = "0.4.5"
-AUTHOR = "Róbert Márki"
-AUTHOR_EMAIL = "gsmiko@gmail.com"
+VERSION = "0.5.0"
+AUTHOR = "Hyperscience"

--- a/aiocometd/_metadata.py
+++ b/aiocometd/_metadata.py
@@ -8,5 +8,5 @@ PROJECT_URLS = {
     "Coverage": "https://coveralls.io/github/robertmrk/aiocometd",
     "Docs": "http://aiocometd.readthedocs.io/"
 }
-VERSION = "0.5.0"
+VERSION = "0.4.5+hs0"
 AUTHOR = "Hyperscience"

--- a/aiocometd/client.py
+++ b/aiocometd/client.py
@@ -509,8 +509,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
         try:
             done, pending = await asyncio.wait(
                 tasks,
-                return_when=asyncio.FIRST_COMPLETED,
-                loop=self._loop)
+                return_when=asyncio.FIRST_COMPLETED)
 
             # cancel all pending tasks
             for task in pending:
@@ -546,7 +545,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
             try:
                 await asyncio.wait_for(
                     self._transport.wait_for_state(TransportState.CONNECTED),
-                    timeout, loop=self._loop
+                    timeout
                 )
             except asyncio.TimeoutError:
                 break

--- a/aiocometd/transports/base.py
+++ b/aiocometd/transports/base.py
@@ -432,7 +432,7 @@ class TransportBase(Transport):  # pylint: disable=too-many-instance-attributes
         :param coro: Coroutine
         :return: Future
         """
-        self._connect_task = asyncio.ensure_future(coro, loop=self._loop)
+        self._connect_task = asyncio.ensure_future(coro)
         self._connect_task.add_done_callback(self._connect_done)
         return self._connect_task
 

--- a/aiocometd/transports/long_polling.py
+++ b/aiocometd/transports/long_polling.py
@@ -22,7 +22,7 @@ class LongPollingTransport(TransportBase):
         super().__init__(**kwargs)
 
         #: semaphore to limit the number of concurrent HTTP connections to 2
-        self._http_semaphore = asyncio.Semaphore(2, loop=self._loop)
+        self._http_semaphore = asyncio.Semaphore(2)
 
     async def _send_final_payload(self, payload: Payload, *,
                                   headers: Headers) -> JsonObject:

--- a/aiocometd/utils.py
+++ b/aiocometd/utils.py
@@ -23,7 +23,7 @@ def defer(coro_func: CoroFunction, delay: Union[int, float, None] = None, *,
     async def wrapper(*args: Any, **kwargs: Any) -> Any:  \
             # pylint: disable=missing-docstring
         if delay:
-            await asyncio.sleep(delay, loop=loop)  # type: ignore
+            await asyncio.sleep(delay)  # type: ignore
         return await coro_func(*args, **kwargs)
 
     return wrapper

--- a/setup.py
+++ b/setup.py
@@ -44,19 +44,17 @@ setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Framework :: AsyncIO",
         "License :: OSI Approved :: MIT License"
     ],
     keywords=metadata["KEYWORDS"],
-    author=metadata["AUTHOR"],
-    author_email=metadata["AUTHOR_EMAIL"],
     url=metadata["URL"],
     project_urls=metadata["PROJECT_URLS"],
     license="MIT",
     packages=find_packages(exclude=("tests*", "examples")),
-    python_requires=">=3.6.0",
+    python_requires=">=3.10.0",
     install_requires=INSTALL_REQUIRES,
     tests_require=TESTS_REQUIRE,
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37
+envlist = py310,py311,py312
 
 [testenv]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
Made `aiocometd` python 3.11 compatible by removing the `loop` arguments and other necessary changes.